### PR TITLE
[Storage] Attempt removing `content_length` param from regenerating

### DIFF
--- a/sdk/storage/azure_storage_blob/examples/storage_logging.rs
+++ b/sdk/storage/azure_storage_blob/examples/storage_logging.rs
@@ -140,7 +140,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .upload(
             RequestContent::from(content.to_vec()),
             true, // overwrite if exists
-            content.len() as u64,
             None,
         )
         .await?;

--- a/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
+++ b/sdk/storage/azure_storage_blob/perf/list_blob_test.rs
@@ -98,7 +98,7 @@ impl PerfTest for ListBlobTest {
             let body = vec![0u8; 1024 * 1024]; // 1 MB blob
             let body_bytes = Bytes::from(body);
 
-            let _result = blob_client.upload(body_bytes.into(), true, 5, None).await?;
+            let _result = blob_client.upload(body_bytes.into(), true, None).await?;
         }
 
         Ok(())

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -275,13 +275,11 @@ impl BlobClient {
     /// * `data` - The blob data to upload.
     /// * `overwrite` - Whether the blob to be uploaded should overwrite the current data. If True, `upload()` will overwrite the existing data.
     ///   If False, the operation will fail with ResourceExistsError.
-    /// * `content_length` - Total length of the blob data to be uploaded.
     /// * `options` - Optional configuration for the request.
     pub async fn upload(
         &self,
         data: RequestContent<Bytes, NoFormat>,
         overwrite: bool,
-        content_length: u64,
         options: Option<BlockBlobClientUploadOptions<'_>>,
     ) -> Result<Response<BlockBlobClientUploadResult, NoFormat>> {
         let mut options = options.unwrap_or_default();
@@ -291,7 +289,7 @@ impl BlobClient {
         }
 
         self.block_blob_client()
-            .upload_internal(data, content_length, Some(options))
+            .upload_internal(data, Some(options))
             .await
     }
 

--- a/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/append_blob_client.rs
@@ -38,7 +38,6 @@ impl AppendBlobClient {
     /// # Arguments
     ///
     /// * `body` - The body of the request.
-    /// * `content_length` - The length of the request.
     /// * `options` - Optional parameters for the request.
     ///
     /// ## Response Headers
@@ -81,7 +80,6 @@ impl AppendBlobClient {
     pub async fn append_block(
         &self,
         body: RequestContent<Bytes, NoFormat>,
-        content_length: u64,
         options: Option<AppendBlobClientAppendBlockOptions<'_>>,
     ) -> Result<Response<AppendBlobClientAppendBlockResult, NoFormat>> {
         let options = options.unwrap_or_default();
@@ -94,7 +92,6 @@ impl AppendBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
@@ -177,7 +174,6 @@ impl AppendBlobClient {
     /// # Arguments
     ///
     /// * `source_url` - Specify a URL to the copy source.
-    /// * `content_length` - The length of the request.
     /// * `options` - Optional parameters for the request.
     ///
     /// ## Response Headers
@@ -220,7 +216,6 @@ impl AppendBlobClient {
     pub async fn append_block_from_url(
         &self,
         source_url: String,
-        content_length: u64,
         options: Option<AppendBlobClientAppendBlockFromUrlOptions<'_>>,
     ) -> Result<Response<AppendBlobClientAppendBlockFromUrlResult, NoFormat>> {
         let options = options.unwrap_or_default();
@@ -233,7 +228,6 @@ impl AppendBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/block_blob_client.rs
@@ -293,7 +293,6 @@ impl BlockBlobClient {
     /// * `block_id` - A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than
     ///   or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the
     ///   same size for each block.
-    /// * `content_length` - The length of the request.
     /// * `body` - The body of the request.
     /// * `options` - Optional parameters for the request.
     ///
@@ -333,7 +332,6 @@ impl BlockBlobClient {
     pub async fn stage_block(
         &self,
         block_id: &[u8],
-        content_length: u64,
         body: RequestContent<Bytes, NoFormat>,
         options: Option<BlockBlobClientStageBlockOptions<'_>>,
     ) -> Result<Response<BlockBlobClientStageBlockResult, NoFormat>> {
@@ -348,7 +346,6 @@ impl BlockBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
@@ -412,7 +409,6 @@ impl BlockBlobClient {
     /// * `block_id` - A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than
     ///   or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the
     ///   same size for each block.
-    /// * `content_length` - The length of the request.
     /// * `source_url` - Specify a URL to the copy source.
     /// * `options` - Optional parameters for the request.
     ///
@@ -452,7 +448,6 @@ impl BlockBlobClient {
     pub async fn stage_block_from_url(
         &self,
         block_id: &[u8],
-        content_length: u64,
         source_url: String,
         options: Option<BlockBlobClientStageBlockFromUrlOptions<'_>>,
     ) -> Result<Response<BlockBlobClientStageBlockFromUrlResult, NoFormat>> {
@@ -467,7 +462,6 @@ impl BlockBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/xml");
         request.insert_header("x-ms-copy-source", source_url);
         if let Some(copy_source_authorization) = options.copy_source_authorization.as_ref() {
@@ -770,7 +764,6 @@ impl BlockBlobClient {
     /// # Arguments
     ///
     /// * `body` - The body of the request.
-    /// * `content_length` - The length of the request.
     /// * `options` - Optional parameters for the request.
     ///
     /// ## Response Headers
@@ -811,7 +804,6 @@ impl BlockBlobClient {
     pub async fn upload_internal(
         &self,
         body: RequestContent<Bytes, NoFormat>,
-        content_length: u64,
         options: Option<BlockBlobClientUploadInternalOptions<'_>>,
     ) -> Result<Response<BlockBlobClientUploadInternalResult, NoFormat>> {
         let options = options.unwrap_or_default();
@@ -823,7 +815,6 @@ impl BlockBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }

--- a/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/page_blob_client.rs
@@ -635,7 +635,6 @@ impl PageBlobClient {
     /// # Arguments
     ///
     /// * `body` - The body of the request.
-    /// * `content_length` - The length of the request.
     /// * `range` - Bytes of data in the specified range.
     /// * `options` - Optional parameters for the request.
     ///
@@ -678,7 +677,6 @@ impl PageBlobClient {
     pub async fn upload_pages(
         &self,
         body: RequestContent<Bytes, NoFormat>,
-        content_length: u64,
         range: String,
         options: Option<PageBlobClientUploadPagesOptions<'_>>,
     ) -> Result<Response<PageBlobClientUploadPagesResult, NoFormat>> {
@@ -692,7 +690,6 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", base64::encode(transactional_content_md5));
         }
@@ -792,7 +789,6 @@ impl PageBlobClient {
     /// * `source_url` - Specify a URL to the copy source.
     /// * `source_range` - Bytes of source data in the specified range. The length of this range should match the ContentLength
     ///   header and x-ms-range/Range destination range header.
-    /// * `content_length` - The length of the request.
     /// * `range` - Bytes of source data in the specified range. The length of this range should match the ContentLength header
     ///   and x-ms-range/Range destination range header.
     /// * `options` - Optional parameters for the request.
@@ -837,7 +833,6 @@ impl PageBlobClient {
         &self,
         source_url: String,
         source_range: String,
-        content_length: u64,
         range: String,
         options: Option<PageBlobClientUploadPagesFromUrlOptions<'_>>,
     ) -> Result<Response<PageBlobClientUploadPagesFromUrlResult, NoFormat>> {
@@ -851,7 +846,6 @@ impl PageBlobClient {
         }
         query_builder.build();
         let mut request = Request::new(url, Method::Put);
-        request.insert_header("content-length", content_length.to_string());
         if let Some(if_match) = options.if_match.as_ref() {
             request.insert_header("if-match", if_match);
         }

--- a/sdk/storage/azure_storage_blob/tests/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/append_blob_client.rs
@@ -50,14 +50,12 @@ async fn test_append_block(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     append_blob_client
         .append_block(
             RequestContent::from(block_1.clone()),
-            u64::try_from(block_1.len())?,
             None,
         )
         .await?;
     append_blob_client
         .append_block(
             RequestContent::from(block_2.clone()),
-            u64::try_from(block_2.len())?,
             None,
         )
         .await?;
@@ -89,7 +87,7 @@ async fn test_append_block_from_url(ctx: TestContext) -> Result<(), Box<dyn Erro
 
     // Act
     append_blob_client
-        .append_block_from_url(blob_client_2.url().as_str().into(), 17, None)
+        .append_block_from_url(blob_client_2.url().as_str().into(), None)
         .await?;
 
     // Assert
@@ -123,7 +121,6 @@ async fn test_seal_append_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let response = append_blob_client
         .append_block(
             RequestContent::from(test_block.clone()),
-            u64::try_from(test_block.len())?,
             None,
         )
         .await;

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -112,7 +112,6 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload(
             RequestContent::from(data.to_vec()),
             false,
-            u64::try_from(data.len())?,
             None,
         )
         .await?;
@@ -136,7 +135,6 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload(
             RequestContent::from(new_data.to_vec()),
             false,
-            u64::try_from(new_data.len())?,
             None,
         )
         .await;
@@ -151,7 +149,6 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload(
             RequestContent::from(new_data.to_vec()),
             true,
-            u64::try_from(new_data.len())?,
             None,
         )
         .await?;
@@ -237,7 +234,6 @@ async fn test_download_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         .upload(
             RequestContent::from(data.to_vec()),
             false,
-            u64::try_from(data.len())?,
             None,
         )
         .await?;
@@ -278,7 +274,6 @@ async fn test_set_blob_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> 
         .upload(
             RequestContent::from(data.to_vec()),
             false,
-            u64::try_from(data.len())?,
             Some(options_with_metadata),
         )
         .await?;
@@ -455,7 +450,6 @@ async fn test_leased_blob_operations(ctx: TestContext) -> Result<(), Box<dyn Err
         .upload(
             RequestContent::from(data.to_vec()),
             true,
-            u64::try_from(data.len())?,
             Some(upload_options),
         )
         .await?;
@@ -610,7 +604,6 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
             .upload(
                 RequestContent::from(b"hello rusty world".to_vec()),
                 true,
-                17,
                 None,
             )
             .await?;
@@ -638,7 +631,6 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
             .upload(
                 RequestContent::from(b"hello rusty world".to_vec()),
                 true,
-                17,
                 None,
             )
             .await?;
@@ -655,7 +647,6 @@ async fn test_encoding_edge_cases(ctx: TestContext) -> Result<(), Box<dyn Error>
             .upload(
                 RequestContent::from(b"hello rusty world".to_vec()),
                 true,
-                17,
                 None,
             )
             .await?;
@@ -966,7 +957,6 @@ async fn test_storage_error_model_additional_info(ctx: TestContext) -> Result<()
 //         .upload(
 //             RequestContent::from(data.to_vec()),
 //             false,
-//             u64::try_from(data.len())?,
 //             None,
 //         )
 //         .await?;
@@ -1015,7 +1005,6 @@ async fn test_storage_error_model_additional_info(ctx: TestContext) -> Result<()
 //         .upload(
 //             RequestContent::from(data.to_vec()),
 //             false,
-//             u64::try_from(data.len())?,
 //             None,
 //         )
 //         .await?;
@@ -1064,7 +1053,6 @@ async fn test_storage_error_model_additional_info(ctx: TestContext) -> Result<()
 //         .upload(
 //             RequestContent::from(data.to_vec()),
 //             false,
-//             u64::try_from(data.len())?,
 //             None,
 //         )
 //         .await?;

--- a/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client_options.rs
@@ -308,7 +308,6 @@ async fn test_blob_version_feature_interactions(ctx: TestContext) -> Result<(), 
         .upload(
             RequestContent::from(data_v1.to_vec()),
             false,
-            u64::try_from(data_v1.len())?,
             None,
         )
         .await?;
@@ -318,7 +317,6 @@ async fn test_blob_version_feature_interactions(ctx: TestContext) -> Result<(), 
         .upload(
             RequestContent::from(data_v2.to_vec()),
             true,
-            u64::try_from(data_v2.len())?,
             None,
         )
         .await?;
@@ -327,13 +325,13 @@ async fn test_blob_version_feature_interactions(ctx: TestContext) -> Result<(), 
     let lease_blob_name = format!("{}-lease", get_blob_name(recording));
     let lease_blob_client = container_client.blob_client(&lease_blob_name);
     lease_blob_client
-        .upload(RequestContent::from(b"v1".to_vec()), false, 2, None)
+        .upload(RequestContent::from(b"v1".to_vec()), false, None)
         .await?;
     let response = lease_blob_client.get_properties(None).await?;
     let lease_version_1 = response.version_id()?.unwrap();
 
     lease_blob_client
-        .upload(RequestContent::from(b"v2".to_vec()), true, 2, None)
+        .upload(RequestContent::from(b"v2".to_vec()), true, None)
         .await?;
 
     // Acquire Lease on Current Version
@@ -521,7 +519,6 @@ async fn test_blob_snapshot_basic_operations(ctx: TestContext) -> Result<(), Box
         .upload(
             RequestContent::from(data_v2.to_vec()),
             true,
-            u64::try_from(data_v2.len())?,
             None,
         )
         .await?;
@@ -868,7 +865,6 @@ async fn test_blob_snapshot_error_cases(ctx: TestContext) -> Result<(), Box<dyn 
         .upload(
             RequestContent::from(data.to_vec()),
             true,
-            u64::try_from(data.len())?,
             None,
         )
         .await;

--- a/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/block_blob_client.rs
@@ -35,7 +35,6 @@ async fn test_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     block_blob_client
         .stage_block(
             &block_1_id,
-            u64::try_from(block_1.len())?,
             RequestContent::from(block_1.to_vec()),
             None,
         )
@@ -44,7 +43,6 @@ async fn test_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     block_blob_client
         .stage_block(
             &block_2_id,
-            u64::try_from(block_2.len())?,
             RequestContent::from(block_2.to_vec()),
             None,
         )
@@ -52,7 +50,6 @@ async fn test_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     block_blob_client
         .stage_block(
             &block_3_id,
-            u64::try_from(block_3.len())?,
             RequestContent::from(block_3.to_vec()),
             None,
         )
@@ -226,7 +223,6 @@ async fn test_stage_block_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     block_blob_client
         .stage_block_from_url(
             &block_id,
-            u64::try_from(source_content.len())?,
             source_blob_client.url().as_str().into(),
             None,
         )
@@ -300,7 +296,6 @@ async fn test_stage_block_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     block_blob_client
         .stage_block_from_url(
             &block_id_2,
-            u64::try_from(source_content_2.len())?,
             source_blob_client_2.url().as_str().into(),
             Some(source_auth_options),
         )

--- a/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/page_blob_client.rs
@@ -68,7 +68,6 @@ async fn test_upload_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     page_blob_client
         .upload_pages(
             RequestContent::from(data.clone()),
-            512,
             format_page_range(0, 512)?,
             None,
         )
@@ -99,7 +98,6 @@ async fn test_clear_page(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     page_blob_client
         .upload_pages(
             RequestContent::from(data),
-            512,
             format_page_range(0, 512)?,
             None,
         )
@@ -136,7 +134,6 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     let response = page_blob_client
         .upload_pages(
             RequestContent::from(data.clone()),
-            1024,
             format_page_range(0, 1024)?,
             None,
         )
@@ -149,7 +146,6 @@ async fn test_resize_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     page_blob_client
         .upload_pages(
             RequestContent::from(data.clone()),
-            1024,
             format_page_range(0, 1024)?,
             None,
         )
@@ -233,7 +229,6 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     page_blob_client_1
         .upload_pages(
             RequestContent::from(data_b.clone()),
-            512,
             format_page_range(0, 512)?,
             None,
         )
@@ -244,7 +239,6 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
     page_blob_client_2
         .upload_pages(
             RequestContent::from(data_a.clone()),
-            512,
             format_page_range(0, 512)?,
             None,
         )
@@ -253,7 +247,6 @@ async fn test_upload_page_from_url(ctx: TestContext) -> Result<(), Box<dyn Error
         .upload_pages_from_url(
             blob_client_1.url().as_str().into(),
             format_page_range(0, data_b.len() as u64)?,
-            data_b.len() as u64,
             format_page_range(512, data_b.len() as u64)?,
             None,
         )
@@ -294,7 +287,6 @@ async fn test_get_page_ranges(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     page_blob_client
         .upload_pages(
             RequestContent::from(data.clone()),
-            512,
             format_page_range(0, 512)?,
             None,
         )

--- a/sdk/storage/azure_storage_blob/tests/streaming.rs
+++ b/sdk/storage/azure_storage_blob/tests/streaming.rs
@@ -38,7 +38,7 @@ async fn upload<const CONTENT_LENGTH: usize>(client: &BlobClient) -> azure_core:
     let stream = GeneratedStream::<_, CONTENT_LENGTH>::default();
 
     client
-        .upload(stream.into(), true, CONTENT_LENGTH as u64, None)
+        .upload(stream.into(), true, None)
         .await?;
 
     Ok(())

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: b0bef4ddc1f6311835ae867d499e5653ced50e25
+commit: 6052863761e4684e1cb85deaa93bd1ea99d07aba
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: 7d42af8056792c4514cd941b9159d0b18e49ab28
+commit: b0bef4ddc1f6311835ae867d499e5653ced50e25
 repo: Azure/azure-rest-api-specs
 additionalDirectories: 

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -155,17 +155,12 @@ pub async fn create_test_blob(
     options: Option<BlockBlobClientUploadOptions<'_>>,
 ) -> Result<Response<BlockBlobClientUploadResult, NoFormat>> {
     match data {
-        Some(content) => {
-            blob_client
-                .upload(content.clone(), true, content.body().len() as u64, options)
-                .await
-        }
+        Some(content) => blob_client.upload(content, true, options).await,
         None => {
             blob_client
                 .upload(
                     RequestContent::from(b"hello rusty world".to_vec()),
                     true,
-                    17,
                     options,
                 )
                 .await


### PR DESCRIPTION
`.tsp:` https://github.com/Azure/azure-rest-api-specs/pull/40373
The above TypeSpec stands up a private alias of content length, and uses the `Access.Internal` decorator:
```typespec
/** The Content-Length header. */
alias ContentLengthParameterPrivate = {
  /** The length of the request. */
  @access(Access.internal)
  @header("Content-Length")
  contentLength: int64;
};
```
then uses that everywhere the original `ContentLengthParameter` was used. However, as this PR shows, this made 0 changes, but I would have expected to see `content_length` get dropped as a parameter.