### PR TITLE
...

### DIFF
--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -14,7 +14,8 @@ use crate::generated::models::{
     BlobContainerClientListFindBlobsByTagsOptions, BlobContainerClientReleaseLeaseOptions,
     BlobContainerClientReleaseLeaseResult, BlobContainerClientRenewLeaseOptions,
     BlobContainerClientRenewLeaseResult, BlobContainerClientSetAccessPolicyOptions,
-    BlobContainerClientSetMetadataOptions, FilteredBlob, ListBlobsResponse, SignedIdentifiers,
+    BlobContainerClientSetMetadataOptions, FilteredBlobResponse, ListBlobsResponse,
+    SignedIdentifiers,
 };
 use azure_core::{
     error::CheckSuccessOptions,
@@ -725,7 +726,7 @@ impl BlobContainerClient {
         &self,
         filter_expression: &str,
         options: Option<BlobContainerClientListFindBlobsByTagsOptions<'_>>,
-    ) -> Result<Pager<FilteredBlob, XmlFormat>> {
+    ) -> Result<Pager<FilteredBlobResponse, XmlFormat>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
@@ -781,7 +782,7 @@ impl BlobContainerClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: FilteredBlob = xml::from_xml(&body)?;
+                    let res: FilteredBlobResponse = xml::from_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -7,7 +7,7 @@ use crate::generated::models::{
     BlobServiceClientGetAccountInfoOptions, BlobServiceClientGetAccountInfoResult,
     BlobServiceClientGetPropertiesOptions, BlobServiceClientGetStatisticsOptions,
     BlobServiceClientListContainersOptions, BlobServiceClientListFindBlobsByTagsOptions,
-    BlobServiceClientSetPropertiesOptions, BlobServiceProperties, FilteredBlob,
+    BlobServiceClientSetPropertiesOptions, BlobServiceProperties, FilteredBlobResponse,
     ListContainersResponse, StorageServiceStats,
 };
 use azure_core::{
@@ -286,7 +286,7 @@ impl BlobServiceClient {
         &self,
         filter_expression: &str,
         options: Option<BlobServiceClientListFindBlobsByTagsOptions<'_>>,
-    ) -> Result<Pager<FilteredBlob, XmlFormat>> {
+    ) -> Result<Pager<FilteredBlobResponse, XmlFormat>> {
         let options = options.unwrap_or_default().into_owned();
         let pipeline = self.pipeline.clone();
         let mut first_url = self.endpoint.clone();
@@ -340,7 +340,7 @@ impl BlobServiceClient {
                         )
                         .await?;
                     let (status, headers, body) = rsp.deconstruct();
-                    let res: FilteredBlob = xml::from_xml(&body)?;
+                    let res: FilteredBlobResponse = xml::from_xml(&body)?;
                     let rsp = RawResponse::from_bytes(status, headers, body).into();
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {

--- a/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/method_options.rs
@@ -9,7 +9,7 @@ use super::{
     ListBlobsIncludeItem, ListContainersIncludeType, PremiumPageBlobAccessTier, PublicAccessType,
     RehydratePriority,
 };
-use crate::models::HttpRange;
+use crate::models::BlobMetadata;
 use azure_core::{
     fmt::SafeDebug,
     http::{pager::PagerOptions, ClientMethodOptions, Etag},
@@ -103,7 +103,7 @@ pub struct AppendBlobClientAppendBlockFromUrlOptions<'a> {
     pub source_if_unmodified_since: Option<OffsetDateTime>,
 
     /// Bytes of source data in the specified range.
-    pub source_range: Option<HttpRange>,
+    pub source_range: Option<BlobMetadata>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
@@ -533,7 +533,7 @@ pub(crate) struct BlobClientDownloadInternalOptions<'a> {
     pub(crate) method_options: ClientMethodOptions<'a>,
 
     /// Return only the bytes of the blob in the specified range.
-    pub(crate) range: Option<HttpRange>,
+    pub(crate) range: Option<BlobMetadata>,
 
     /// Optional. When this header is set to true and specified together with the Range header, the service returns the CRC64
     /// hash for the range, as long as the range is less than or equal to 4 MB in size.
@@ -1509,7 +1509,7 @@ pub struct BlockBlobClientStageBlockFromUrlOptions<'a> {
     pub source_if_unmodified_since: Option<OffsetDateTime>,
 
     /// Bytes of source data in the specified range.
-    pub source_range: Option<HttpRange>,
+    pub source_range: Option<BlobMetadata>,
 
     /// The timeout parameter is expressed in seconds. For more information, see [Setting Timeouts for Blob Service Operations.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations)
     pub timeout: Option<i32>,
@@ -1959,7 +1959,7 @@ pub struct PageBlobClientGetPageRangesOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 
     /// Return only the bytes of the blob in the specified range.
-    pub range: Option<HttpRange>,
+    pub range: Option<BlobMetadata>,
 
     /// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
     /// information on working with blob snapshots, see [Creating a Snapshot of a Blob.](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob)

--- a/sdk/storage/azure_storage_blob/src/generated/models/models.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models.rs
@@ -6,13 +6,14 @@
 use super::{
     models_serde,
     xml_helpers::{
-        Blob_itemsBlob, Blob_tag_setTag, BlobsBlob, Committed_blocksBlock,
-        Container_itemsContainer, CorsCorsRule, Uncommitted_blocksBlock,
+        Blob_itemsBlob, Blob_tag_setTag, Committed_blocksBlock, Container_itemsContainer,
+        CorsCorsRule, Uncommitted_blocksBlock,
     },
     AccessTier, ArchiveStatus, BlobType, CopyStatus, GeoReplicationStatusType,
     ImmutabilityPolicyMode, LeaseDuration, LeaseState, LeaseStatus, PublicAccessType,
     RehydratePriority, StorageErrorCode,
 };
+use crate::models::BlobMetadata;
 use azure_core::{base64, fmt::SafeDebug, http::Etag, time::OffsetDateTime};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -146,7 +147,7 @@ pub struct BlobItem {
 
     /// The metadata of the blob.
     #[serde(rename = "Metadata", skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<HashMap<String, String>>,
+    pub metadata: Option<BlobMetadata>,
 
     /// The name of the blob.
     #[serde(
@@ -823,15 +824,15 @@ pub struct FilterBlobItem {
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
 #[serde(rename = "EnumerationResults")]
-pub struct FilteredBlob {
+pub struct FilteredBlobResponse {
     /// The blob segment.
     #[serde(
         default,
-        deserialize_with = "BlobsBlob::unwrap",
+        deserialize_with = "Blob_itemsBlob::unwrap",
         rename = "Blobs",
-        serialize_with = "BlobsBlob::wrap"
+        serialize_with = "Blob_itemsBlob::wrap"
     )]
-    pub blobs: Vec<FilterBlobItem>,
+    pub blob_items: Vec<FilterBlobItem>,
 
     /// The next marker of the blobs.
     #[serde(rename = "NextMarker", skip_serializing_if = "Option::is_none")]
@@ -904,7 +905,7 @@ pub struct ListBlobsResponse {
     pub service_endpoint: Option<String>,
 }
 
-/// The list container segment response
+/// The list containers response.
 #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
 #[non_exhaustive]
 #[serde(rename = "EnumerationResults")]

--- a/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/models_impl.rs
@@ -5,7 +5,7 @@
 
 use super::{
     BlobItem, BlobServiceProperties, BlobTags, BlockLookupList, ContainerItem, FilterBlobItem,
-    FilteredBlob, ListBlobsResponse, ListContainersResponse, SignedIdentifiers,
+    FilteredBlobResponse, ListBlobsResponse, ListContainersResponse, SignedIdentifiers,
 };
 use async_trait::async_trait;
 use azure_core::{
@@ -15,11 +15,11 @@ use azure_core::{
 };
 
 #[async_trait]
-impl Page for FilteredBlob {
+impl Page for FilteredBlobResponse {
     type Item = FilterBlobItem;
     type IntoIter = <Vec<FilterBlobItem> as IntoIterator>::IntoIter;
     async fn into_items(self) -> Result<Self::IntoIter> {
-        Ok(self.blobs.into_iter())
+        Ok(self.blob_items.into_iter())
     }
 }
 

--- a/sdk/storage/azure_storage_blob/src/generated/models/xml_helpers.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/models/xml_helpers.rs
@@ -6,25 +6,25 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use super::{BlobItem, BlobTag, Block, ContainerItem, CorsRule, FilterBlobItem};
+use super::{BlobTag, Block, ContainerItem, CorsRule, FilterBlobItem};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename = "Blobs")]
 pub(crate) struct Blob_itemsBlob {
     #[serde(default)]
-    Blob: Vec<BlobItem>,
+    Blob: Vec<FilterBlobItem>,
 }
 
 impl Blob_itemsBlob {
-    pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<BlobItem>, D::Error>
+    pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<FilterBlobItem>, D::Error>
     where
         D: Deserializer<'de>,
     {
         Ok(Blob_itemsBlob::deserialize(deserializer)?.Blob)
     }
 
-    pub fn wrap<S>(to_serialize: &Vec<BlobItem>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn wrap<S>(to_serialize: &Vec<FilterBlobItem>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -56,32 +56,6 @@ impl Blob_tag_setTag {
     {
         Blob_tag_setTag {
             Tag: to_serialize.to_owned(),
-        }
-        .serialize(serializer)
-    }
-}
-
-#[derive(Deserialize, Serialize)]
-#[serde(rename = "Blobs")]
-pub(crate) struct BlobsBlob {
-    #[serde(default)]
-    Blob: Vec<FilterBlobItem>,
-}
-
-impl BlobsBlob {
-    pub fn unwrap<'de, D>(deserializer: D) -> Result<Vec<FilterBlobItem>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(BlobsBlob::deserialize(deserializer)?.Blob)
-    }
-
-    pub fn wrap<S>(to_serialize: &Vec<FilterBlobItem>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        BlobsBlob {
-            Blob: to_serialize.to_owned(),
         }
         .serialize(serializer)
     }

--- a/sdk/storage/azure_storage_blob/tsp-location.yaml
+++ b/sdk/storage/azure_storage_blob/tsp-location.yaml
@@ -1,4 +1,4 @@
 directory: specification/storage/Microsoft.BlobStorage
-commit: ab795993f94e0f65c07e0304edb33647ae5cf874
+commit: b3dc5c4da2d5fcf27a4c8446b139cf274aa54517
 repo: Azure/azure-rest-api-specs
-additionalDirectories:
+additionalDirectories: 


### PR DESCRIPTION
https://github.com/Azure/azure-rest-api-specs/pull/42894

```
   Compiling azure_storage_blob v0.13.0 (C:\azure-sdk-for-rust\sdk\storage\azure_storage_blob)
error[E0432]: unresolved import `crate::models::BlobMetadata`                                                                                                                                                     
  --> sdk\storage\azure_storage_blob\src\generated\models\method_options.rs:12:5
   |
12 | use crate::models::BlobMetadata;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `BlobMetadata` in `models`

error[E0432]: unresolved import `crate::models::BlobMetadata`
  --> sdk\storage\azure_storage_blob\src\generated\models\models.rs:16:5
   |
16 | use crate::models::BlobMetadata;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `BlobMetadata` in `models`

error[E0282]: type annotations needed                                                                                                                                                                             
   --> sdk\storage\azure_storage_blob\src\generated\clients\append_blob_client.rs:345:56
    |
345 |             request.insert_header("x-ms-source-range", source_range.to_string());
    |                                                        ^^^^^^^^^^^^ cannot infer type

error[E0282]: type annotations needed                                                                                                                                                                             
   --> sdk\storage\azure_storage_blob\src\generated\clients\blob_client.rs:668:44
    |
668 |             request.insert_header("range", range.to_string());
    |                                            ^^^^^ cannot infer type

error[E0308]: `?` operator has incompatible types                                                                                                                                                                 
   --> sdk\storage\azure_storage_blob\src\generated\models\models.rs:877:28nt.rs:554:56
    |
877 |         deserialize_with = "Blob_itemsBlob::unwrap",", source_range.to_string());
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^ expected `Vec<BlobItem>`, found `Vec<FilterBlobItem>`
    |
    = note: `?` operator cannot convert from `Vec<generated::models::models::FilterBlobItem>` to `Vec<generated::models::models::BlobItem>`
    = note: expected struct `Vec<generated::models::models::BlobItem>`client.rs:414:44
               found struct `Vec<generated::models::models::FilterBlobItem>`
414 |             request.insert_header("range", range.to_string());
error[E0308]: mismatched types                                                                                                                                                                                    
   --> sdk\storage\azure_storage_blob\src\generated\models\models.rs:870:50
    |
870 | #[derive(Clone, Default, Deserialize, SafeDebug, Serialize)]
    |                                                  ^^^^^^^^^ expected `&Vec<FilterBlobItem>`, found `&Vec<BlobItem>`
...
879 |         serialize_with = "Blob_itemsBlob::wrap"
    |                          ---------------------- arguments to this function are incorrect
    |
    = note: expected reference `&Vec<generated::models::models::FilterBlobItem>`
               found reference `&'__a Vec<generated::models::models::BlobItem>`
note: associated function defined here
   --> sdk\storage\azure_storage_blob\src\generated\models\xml_helpers.rs:27:12
    |
 27 |     pub fn wrap<S>(to_serialize: &Vec<FilterBlobItem>, serializer: S) -> Result<S::Ok, S::Error>
    |            ^^^^    ----------------------------------
    = note: this error originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)
```